### PR TITLE
remove special characters from base url

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,6 +1,6 @@
 theme = "edidor"
 title = "Edidor Demo"
-baseurl = "https://your site url"
+baseurl = "https://your-site-url"
 AuthorName = "Jon Doe"
 # place your logo file to ./static/images to set logo
 


### PR DESCRIPTION
When installing this theme with blogdown in r studio the spaces in your example base URL cause an error. Filling it with a dash instead off a space fixed the issue for me.